### PR TITLE
Always allow app CRs with a deletion timestamp

### DIFF
--- a/helm/app-admission-controller/templates/_helpers.tpl
+++ b/helm/app-admission-controller/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Common labels
 {{- define "labels.common" -}}
 app: {{ include "name" . | quote }}
 {{ include "labels.selector" . }}
-app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
+app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/integration/test/validation/app_test.go
+++ b/integration/test/validation/app_test.go
@@ -4,6 +4,7 @@ package validation
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	appName       = "dex-app"
+	catalog       = "control-plane-catalog"
+	configMapName = "dex-config"
+	namespace     = "test"
 )
 
 // TestFailWhenCatalogNotFound tests that the app CR is rejected if the
@@ -26,7 +35,7 @@ func TestFailWhenCatalogNotFound(t *testing.T) {
 
 	app := &v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dex-app-unique",
+			Name:      appName,
 			Namespace: "giantswarm",
 			Labels: map[string]string{
 				label.AppOperatorVersion: "0.0.0",
@@ -34,7 +43,7 @@ func TestFailWhenCatalogNotFound(t *testing.T) {
 		},
 		Spec: v1alpha1.AppSpec{
 			Catalog:   "missing",
-			Name:      "dex-app",
+			Name:      appName,
 			Namespace: "giantswarm",
 			KubeConfig: v1alpha1.AppSpecKubeConfig{
 				InCluster: true,
@@ -57,7 +66,7 @@ func TestFailWhenCatalogNotFound(t *testing.T) {
 
 		return nil
 	}
-	b := backoff.NewConstant(5*time.Minute, 30*time.Second)
+	b := backoff.NewConstant(5*time.Minute, 10*time.Second)
 	n := backoff.NewNotifier(logger, ctx)
 
 	err = backoff.RetryNotify(o, b, n)
@@ -68,42 +77,95 @@ func TestFailWhenCatalogNotFound(t *testing.T) {
 	logger.LogCtx(ctx, "level", "debug", "message", "waited for failed app creation")
 }
 
-// TestSkipValidationOnDelete tests that the validation is skipped when the app
-// CR is deleted. Both an app CR and configmap are created and the configmap is
-// deleted first.
-func TestSkipValidationOnDelete(t *testing.T) {
+// TestSkipValidationOnNamespaceDeletion tests that when the namespace
+// containing an app CR is deleted the validation logic is skipped. This is
+// done by checking if the app CR has a deletion timestamp.
+func TestSkipValidationOnNamespaceDeletion(t *testing.T) {
 	ctx := context.Background()
 
 	var err error
+
+	logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating test resources in %#q namespace", namespace))
+
+	err = createTestResources(ctx)
+	if err != nil {
+		t.Fatalf("expected nil but got error %#v", err)
+	}
+
+	logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created test resources in %#q namespace", namespace))
+
+	logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q namespace", namespace))
+
+	err = appTest.K8sClient().CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("expected nil but got error %#v", err)
+	}
+
+	logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %#q namespace", namespace))
+
+	logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for %#q app deletion", appName))
+
+	app := &v1alpha1.App{}
+
+	o := func() error {
+		err = appTest.CtrlClient().Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, app)
+		if apierrors.IsNotFound(err) {
+			// fall through
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+	}
+	b := backoff.NewConstant(5*time.Minute, 10*time.Second)
+	n := backoff.NewNotifier(logger, ctx)
+
+	err = backoff.RetryNotify(o, b, n)
+	if err != nil {
+		t.Fatalf("expected nil but got error %#v", err)
+	}
+
+	logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for %#q app deletion", appName))
+}
+
+func createTestResources(ctx context.Context) error {
+	var err error
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
 
 	cm := &corev1.ConfigMap{
 		Data: map[string]string{
 			"values": "values",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dex-config",
-			Namespace: "giantswarm",
+			Name:      configMapName,
+			Namespace: namespace,
 		},
 	}
 
 	app := &v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dex-app-unique",
-			Namespace: "giantswarm",
+			Name:      appName,
+			Namespace: namespace,
 			Labels: map[string]string{
 				label.AppOperatorVersion: "0.0.0",
 			},
 		},
 		Spec: v1alpha1.AppSpec{
-			Catalog: "control-plane-catalog",
+			Catalog: catalog,
 			Config: v1alpha1.AppSpecConfig{
 				ConfigMap: v1alpha1.AppSpecConfigConfigMap{
-					Name:      "dex-config",
-					Namespace: "giantswarm",
+					Name:      configMapName,
+					Namespace: namespace,
 				},
 			},
-			Name:      "dex-app",
-			Namespace: "giantswarm",
+			Name:      appName,
+			Namespace: namespace,
 			KubeConfig: v1alpha1.AppSpecKubeConfig{
 				InCluster: true,
 			},
@@ -111,10 +173,16 @@ func TestSkipValidationOnDelete(t *testing.T) {
 		},
 	}
 
-	logger.LogCtx(ctx, "level", "debug", "message", "creating app and configmap")
-
 	o := func() error {
-		_, err = appTest.K8sClient().CoreV1().ConfigMaps("giantswarm").Create(ctx, cm, metav1.CreateOptions{})
+		_, err = appTest.K8sClient().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		_, err = appTest.K8sClient().CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			// fall through
 			return nil
@@ -132,31 +200,13 @@ func TestSkipValidationOnDelete(t *testing.T) {
 
 		return nil
 	}
-	b := backoff.NewConstant(5*time.Minute, 30*time.Second)
+	b := backoff.NewConstant(5*time.Minute, 10*time.Second)
 	n := backoff.NewNotifier(logger, ctx)
 
 	err = backoff.RetryNotify(o, b, n)
 	if err != nil {
-		t.Fatalf("expected nil but got error %#v", err)
+		return microerror.Mask(err)
 	}
 
-	logger.LogCtx(ctx, "level", "debug", "message", "created app and configmap")
-
-	logger.LogCtx(ctx, "level", "debug", "message", "deleting configmap")
-
-	err = appTest.K8sClient().CoreV1().ConfigMaps("giantswarm").Delete(ctx, "dex-config", metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("expected nil but got error %#v", err)
-	}
-
-	logger.LogCtx(ctx, "level", "debug", "message", "deleted configmap")
-
-	logger.LogCtx(ctx, "level", "debug", "message", "deleting app")
-
-	err = appTest.CtrlClient().Delete(ctx, app)
-	if err != nil {
-		t.Fatalf("expected nil but got error %#v", err)
-	}
-
-	logger.LogCtx(ctx, "level", "debug", "message", "deleted app")
+	return nil
 }

--- a/integration/test/validation/app_test.go
+++ b/integration/test/validation/app_test.go
@@ -12,9 +12,13 @@ import (
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// TestFailWhenCatalogNotFound tests that the app CR is rejected if the
+// referenced appcatalog CR does not exist.
 func TestFailWhenCatalogNotFound(t *testing.T) {
 	ctx := context.Background()
 
@@ -62,4 +66,97 @@ func TestFailWhenCatalogNotFound(t *testing.T) {
 	}
 
 	logger.LogCtx(ctx, "level", "debug", "message", "waited for failed app creation")
+}
+
+// TestSkipValidationOnDelete tests that the validation is skipped when the app
+// CR is deleted. Both an app CR and configmap are created and the configmap is
+// deleted first.
+func TestSkipValidationOnDelete(t *testing.T) {
+	ctx := context.Background()
+
+	var err error
+
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			"values": "values",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dex-config",
+			Namespace: "giantswarm",
+		},
+	}
+
+	app := &v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dex-app-unique",
+			Namespace: "giantswarm",
+			Labels: map[string]string{
+				label.AppOperatorVersion: "0.0.0",
+			},
+		},
+		Spec: v1alpha1.AppSpec{
+			Catalog: "control-plane-catalog",
+			Config: v1alpha1.AppSpecConfig{
+				ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+					Name:      "dex-config",
+					Namespace: "giantswarm",
+				},
+			},
+			Name:      "dex-app",
+			Namespace: "giantswarm",
+			KubeConfig: v1alpha1.AppSpecKubeConfig{
+				InCluster: true,
+			},
+			Version: "1.2.2",
+		},
+	}
+
+	logger.LogCtx(ctx, "level", "debug", "message", "creating app and configmap")
+
+	o := func() error {
+		_, err = appTest.K8sClient().CoreV1().ConfigMaps("giantswarm").Create(ctx, cm, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = appTest.CtrlClient().Create(ctx, app)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+	}
+	b := backoff.NewConstant(5*time.Minute, 30*time.Second)
+	n := backoff.NewNotifier(logger, ctx)
+
+	err = backoff.RetryNotify(o, b, n)
+	if err != nil {
+		t.Fatalf("expected nil but got error %#v", err)
+	}
+
+	logger.LogCtx(ctx, "level", "debug", "message", "created app and configmap")
+
+	logger.LogCtx(ctx, "level", "debug", "message", "deleting configmap")
+
+	err = appTest.K8sClient().CoreV1().ConfigMaps("giantswarm").Delete(ctx, "dex-config", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("expected nil but got error %#v", err)
+	}
+
+	logger.LogCtx(ctx, "level", "debug", "message", "deleted configmap")
+
+	logger.LogCtx(ctx, "level", "debug", "message", "deleting app")
+
+	err = appTest.CtrlClient().Delete(ctx, app)
+	if err != nil {
+		t.Fatalf("expected nil but got error %#v", err)
+	}
+
+	logger.LogCtx(ctx, "level", "debug", "message", "deleted app")
 }

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -78,9 +78,6 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 
 	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("validating app %#q in namespace %#q", app.Name, app.Namespace))
 
-	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("DEBUG admission request %#v", request))
-	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("DEBUG app %#v", app))
-
 	if !app.DeletionTimestamp.IsZero() {
 		v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("admitted deleted app %#q in namespace %#q", app.Name, app.Namespace))
 		return true, nil

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -78,6 +78,8 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 
 	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("validating app %#q in namespace %#q", app.Name, app.Namespace))
 
+	// We check the deletion timestamp rather than for a delete event because
+	// app CRs may be deleted by deleting the namespace they belong to.
 	if !app.DeletionTimestamp.IsZero() {
 		v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("admitted deleted app %#q in namespace %#q", app.Name, app.Namespace))
 		return true, nil

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 
 	"github.com/giantswarm/app-admission-controller/pkg/validator"
 )
@@ -71,6 +72,11 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 	ctx := context.Background()
 
 	var app v1alpha1.App
+
+	if request.Operation == admissionv1beta1.Delete {
+		v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("admitted %#q operation for app %#q in namespace %#q", request.Operation, app.Name, app.Namespace))
+		return true, nil
+	}
 
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, &app); err != nil {
 		return false, microerror.Maskf(parsingFailedError, "unable to parse app: %#v", err)

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -73,6 +73,8 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 
 	var app v1alpha1.App
 
+	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("DEBUG admission request %#v", request))
+
 	if request.Operation == admissionv1beta1.Delete {
 		v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("admitted %#q operation for app %#q in namespace %#q", request.Operation, app.Name, app.Namespace))
 		return true, nil

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -81,7 +81,7 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 	// We check the deletion timestamp rather than for a delete event because
 	// app CRs may be deleted by deleting the namespace they belong to.
 	if !app.DeletionTimestamp.IsZero() {
-		v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("admitted deleted app %#q in namespace %#q", app.Name, app.Namespace))
+		v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("admitted deletion of app %#q in namespace %#q", app.Name, app.Namespace))
 		return true, nil
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11656

If the deletion timestamp is set on the app CR we skip the validation. This covers when app CRs are deleted directly or by deleting the namespace they belong to.
