### PR TITLE
Default labels for app CRs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/giantswarm/app-admission-controller
 go 1.15
 
 require (
-	github.com/giantswarm/apiextensions/v3 v3.7.0
-	github.com/giantswarm/app/v3 v3.2.0
+	github.com/giantswarm/apiextensions/v3 v3.7.1-0.20201111144349-4ed00f3702ef
+	github.com/giantswarm/app/v3 v3.2.1-0.20201111144832-2ec3df0b5723
 	github.com/giantswarm/apptest v0.5.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.0.0

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.0
-	github.com/giantswarm/apiextensions/v3 v3.7.1-0.20201111144349-4ed00f3702ef
-	github.com/giantswarm/app/v3 v3.2.1-0.20201111144832-2ec3df0b5723
+	github.com/giantswarm/apiextensions/v3 v3.8.0
+	github.com/giantswarm/app/v3 v3.3.0
 	github.com/giantswarm/apptest v0.5.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/giantswarm/app-admission-controller
 go 1.15
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/giantswarm/apiextensions/v3 v3.7.1-0.20201111144349-4ed00f3702ef
 	github.com/giantswarm/app/v3 v3.2.1-0.20201111144832-2ec3df0b5723
 	github.com/giantswarm/apptest v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -196,10 +196,10 @@ github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYis
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions/v3 v3.4.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/apiextensions/v3 v3.7.0 h1:KUAjZn3OMMkmTWvgAfAPTLdrNbFY2zukMntdeLhMGY4=
-github.com/giantswarm/apiextensions/v3 v3.7.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/app/v3 v3.2.0 h1:pBVQ22hRytYEM4WBv2iztBczBcWomxSiOdgLHoiu9HA=
-github.com/giantswarm/app/v3 v3.2.0/go.mod h1:1P9plfrJ5IzG9sg4nw93a6G1mDSLUHBDL5TLaxlRTHc=
+github.com/giantswarm/apiextensions/v3 v3.7.1-0.20201111144349-4ed00f3702ef h1:u4idsdMQ1UerKMShBLkxM1Srlf+xGW7vIra0Rt47XYU=
+github.com/giantswarm/apiextensions/v3 v3.7.1-0.20201111144349-4ed00f3702ef/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
+github.com/giantswarm/app/v3 v3.2.1-0.20201111144832-2ec3df0b5723 h1:e7nqklMWRPuSke7heM4++qydULRRHEV715E8ylfeLyw=
+github.com/giantswarm/app/v3 v3.2.1-0.20201111144832-2ec3df0b5723/go.mod h1:pv1mIPWxGR67krnix79v25ddg/2Gwm214gfvtk/K3iE=
 github.com/giantswarm/appcatalog v0.2.7 h1:SVD1OH/C5zEP8TaeS3L9t8+lVcfaRZhwY98sn8v9lYs=
 github.com/giantswarm/appcatalog v0.2.7/go.mod h1:WHO5lJvcuwzToxxHPdiX9CVxvMsmP8YZfjoo4E/NTLs=
 github.com/giantswarm/apptest v0.5.0 h1:WGHEe5UDO9Rtn61s7/Osh/pF17JXThuc4JXyzPYeHJ0=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZE/rU8pmrbihA=
 github.com/Masterminds/squirrel v1.4.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=

--- a/go.sum
+++ b/go.sum
@@ -197,10 +197,10 @@ github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYis
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions/v3 v3.4.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/apiextensions/v3 v3.7.1-0.20201111144349-4ed00f3702ef h1:u4idsdMQ1UerKMShBLkxM1Srlf+xGW7vIra0Rt47XYU=
-github.com/giantswarm/apiextensions/v3 v3.7.1-0.20201111144349-4ed00f3702ef/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/app/v3 v3.2.1-0.20201111144832-2ec3df0b5723 h1:e7nqklMWRPuSke7heM4++qydULRRHEV715E8ylfeLyw=
-github.com/giantswarm/app/v3 v3.2.1-0.20201111144832-2ec3df0b5723/go.mod h1:pv1mIPWxGR67krnix79v25ddg/2Gwm214gfvtk/K3iE=
+github.com/giantswarm/apiextensions/v3 v3.8.0 h1:gRqlNE62k49EdXYKBaShH0jkFBoOuGPxIgEnD5SZCx4=
+github.com/giantswarm/apiextensions/v3 v3.8.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
+github.com/giantswarm/app/v3 v3.3.0 h1:Mpwc3+dHZKGTNl3y50F6QjVbiBQrgpZGTZfvax+xZKE=
+github.com/giantswarm/app/v3 v3.3.0/go.mod h1:1+kDyJBXp127yVXTdqfgWfGp50V4LkIq1lSDXBizICk=
 github.com/giantswarm/appcatalog v0.2.7 h1:SVD1OH/C5zEP8TaeS3L9t8+lVcfaRZhwY98sn8v9lYs=
 github.com/giantswarm/appcatalog v0.2.7/go.mod h1:WHO5lJvcuwzToxxHPdiX9CVxvMsmP8YZfjoo4E/NTLs=
 github.com/giantswarm/apptest v0.5.0 h1:WGHEe5UDO9Rtn61s7/Osh/pF17JXThuc4JXyzPYeHJ0=

--- a/integration/test/validation/app_test.go
+++ b/integration/test/validation/app_test.go
@@ -38,7 +38,7 @@ func TestFailWhenCatalogNotFound(t *testing.T) {
 			Name:      appName,
 			Namespace: "giantswarm",
 			Labels: map[string]string{
-				label.AppOperatorVersion: "0.0.0",
+				label.AppOperatorVersion: "3.0.0",
 			},
 		},
 		Spec: v1alpha1.AppSpec{
@@ -153,7 +153,7 @@ func createTestResources(ctx context.Context) error {
 			Name:      appName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				label.AppOperatorVersion: "0.0.0",
+				label.AppOperatorVersion: "3.0.0",
 			},
 		},
 		Spec: v1alpha1.AppSpec{

--- a/pkg/app/mutate_app.go
+++ b/pkg/app/mutate_app.go
@@ -3,13 +3,18 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/v3/pkg/clientset/versioned"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/app/v3/pkg/key"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/app-admission-controller/pkg/mutator"
 )
@@ -85,6 +90,14 @@ func (m *Mutator) Mutate(request *v1beta1.AdmissionRequest) ([]mutator.PatchOper
 func (m *Mutator) MutateApp(ctx context.Context, app v1alpha1.App) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
 
+	labelPatches, err := m.mutateLabels(ctx, app)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if len(labelPatches) > 0 {
+		result = append(result, labelPatches...)
+	}
+
 	configPatches, err := m.mutateConfig(ctx, app)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -154,4 +167,47 @@ func (m *Mutator) mutateKubeConfig(ctx context.Context, app v1alpha1.App) ([]mut
 	}))
 
 	return result, nil
+}
+
+func (m *Mutator) mutateLabels(ctx context.Context, app v1alpha1.App) ([]mutator.PatchOperation, error) {
+	var result []mutator.PatchOperation
+
+	// Set app label if there is no app label present.
+	if key.AppKubernetesNameLabel(app) == "" && key.AppLabel(app) == "" {
+		result = append(result, mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", replaceToEscape(label.AppKubernetesName)), key.AppName(app)))
+	}
+
+	// Set version label to be the same as the chart-operator app CR. This
+	// is the version we need and means we don't need to check for a cluster CR.
+	if key.VersionLabel(app) == "" {
+		appVersion, err := getChartOperatorAppVersion(ctx, m.k8sClient.G8sClient(), app.Namespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		if appVersion != "" {
+			result = append(result, mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", replaceToEscape(label.AppOperatorVersion)), appVersion))
+		}
+	}
+
+	if len(app.Labels) == 0 {
+		root := mutator.PatchAdd("/metadata/labels", map[string]string{})
+		result = append([]mutator.PatchOperation{root}, result...)
+	}
+
+	return result, nil
+}
+
+func getChartOperatorAppVersion(ctx context.Context, g8sClient versioned.Interface, namespace string) (string, error) {
+	chartOperatorApp, err := g8sClient.ApplicationV1alpha1().Apps(namespace).Get(ctx, "chart-operator", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return "", nil
+	} else if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return key.VersionLabel(*chartOperatorApp), nil
+}
+
+func replaceToEscape(from string) string {
+	return strings.Replace(from, "/", "~1", -1)
 }

--- a/pkg/app/mutate_app_test.go
+++ b/pkg/app/mutate_app_test.go
@@ -52,7 +52,7 @@ func Test_MutateApp(t *testing.T) {
 						Name:      "chart-operator",
 						Namespace: "eggs2",
 						Labels: map[string]string{
-							label.AppOperatorVersion: "2.6.0",
+							label.AppOperatorVersion: "3.0.0",
 						},
 					},
 				},
@@ -60,7 +60,7 @@ func Test_MutateApp(t *testing.T) {
 			expectedPatches: []mutator.PatchOperation{
 				mutator.PatchAdd("/metadata/labels", map[string]string{}),
 				mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", replaceToEscape(label.AppKubernetesName)), "kiam"),
-				mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", replaceToEscape(label.AppOperatorVersion)), "2.6.0"),
+				mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", replaceToEscape(label.AppOperatorVersion)), "3.0.0"),
 				mutator.PatchAdd("/spec/config", map[string]string{}),
 				mutator.PatchAdd("/spec/config/configMap", map[string]string{
 					"namespace": "eggs2",
@@ -83,6 +83,7 @@ func Test_MutateApp(t *testing.T) {
 					Namespace: "eggs2",
 					Labels: map[string]string{
 						"app.kubernetes.io/name": "kiam",
+						label.AppOperatorVersion: "3.0.0",
 					},
 				},
 				Spec: v1alpha1.AppSpec{
@@ -117,6 +118,7 @@ func Test_MutateApp(t *testing.T) {
 					Namespace: "eggs2",
 					Labels: map[string]string{
 						"app.kubernetes.io/name": "kiam",
+						label.AppOperatorVersion: "3.0.0",
 					},
 				},
 				Spec: v1alpha1.AppSpec{
@@ -150,6 +152,7 @@ func Test_MutateApp(t *testing.T) {
 					Namespace: "eggs2",
 					Labels: map[string]string{
 						"app.kubernetes.io/name": "kiam",
+						label.AppOperatorVersion: "3.0.0",
 					},
 				},
 				Spec: v1alpha1.AppSpec{
@@ -160,6 +163,17 @@ func Test_MutateApp(t *testing.T) {
 						InCluster: true,
 					},
 					Version: "1.4.0",
+				},
+			},
+			apps: []*v1alpha1.App{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "chart-operator",
+						Namespace: "eggs2",
+						Labels: map[string]string{
+							label.AppOperatorVersion: "3.0.0",
+						},
+					},
 				},
 			},
 			expectedPatches: []mutator.PatchOperation{
@@ -202,13 +216,13 @@ func Test_MutateApp(t *testing.T) {
 						Name:      "chart-operator",
 						Namespace: "eggs2",
 						Labels: map[string]string{
-							label.AppOperatorVersion: "2.4.0",
+							label.AppOperatorVersion: "3.0.0",
 						},
 					},
 				},
 			},
 			expectedPatches: []mutator.PatchOperation{
-				mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", replaceToEscape(label.AppOperatorVersion)), "2.4.0"),
+				mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", replaceToEscape(label.AppOperatorVersion)), "3.0.0"),
 			},
 		},
 	}


### PR DESCRIPTION
Towards giantswarm/giantswarm#11656

```yaml
#nginx-ic.yaml
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: nginx-ingress-controller
  namespace: 3zjhk
spec:
  catalog: default
  kubeConfig:
    inCluster: false
  name: nginx-ingress-controller-app
  namespace: kube-system
  version: 1.10.0
```

```bash
k apply -f nginx-ic.yaml
k -n 3zjhk get app nginx-ingress-controller -o yaml
```

```yaml
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 2.3.5
    app.kubernetes.io/name: nginx-ingress-controller-app
  name: nginx-ingress-controller
  namespace: 3zjhk
spec:
  catalog: default
  config:
    configMap:
      name: ingress-controller-values
      namespace: 3zjhk
  kubeConfig:
    context:
      name: 3zjhk
    inCluster: false
    secret:
      name: 3zjhk-kubeconfig
      namespace: 3zjhk
  name: nginx-ingress-controller-app
  namespace: kube-system
  version: 1.10.0
```

