### PR TITLE
Only default cluster values or kubeconfig if they exist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/giantswarm/apiextensions/v3 v3.8.0
-	github.com/giantswarm/app/v3 v3.3.0
+	github.com/giantswarm/app/v3 v3.3.1-0.20201125171539-804e2ceca77c
 	github.com/giantswarm/apptest v0.5.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.0.0
 	github.com/giantswarm/microerror v0.2.1
 	github.com/giantswarm/micrologger v0.3.4
-	github.com/google/go-cmp v0.5.2
+	github.com/google/go-cmp v0.5.3
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/onsi/ginkgo v1.14.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/giantswarm/apiextensions/v3 v3.8.0
-	github.com/giantswarm/app/v3 v3.3.1-0.20201126102224-e38557e5be74
+	github.com/giantswarm/app/v3 v3.5.0
 	github.com/giantswarm/apptest v0.7.1
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.0.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/giantswarm/apiextensions/v3 v3.8.0
-	github.com/giantswarm/app/v3 v3.3.1-0.20201125171539-804e2ceca77c
+	github.com/giantswarm/app/v3 v3.3.1-0.20201126093846-304e2ba5593a
 	github.com/giantswarm/apptest v0.5.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.0.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/giantswarm/apiextensions/v3 v3.8.0
-	github.com/giantswarm/app/v3 v3.3.1-0.20201126093846-304e2ba5593a
+	github.com/giantswarm/app/v3 v3.3.1-0.20201126102224-e38557e5be74
 	github.com/giantswarm/apptest v0.5.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions/v3 v3.4.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
 github.com/giantswarm/apiextensions/v3 v3.8.0 h1:gRqlNE62k49EdXYKBaShH0jkFBoOuGPxIgEnD5SZCx4=
 github.com/giantswarm/apiextensions/v3 v3.8.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/app/v3 v3.3.1-0.20201125171539-804e2ceca77c h1:Znj4g0fMfLWzUzLD/8NuUsMBXBmO3osjvXtqFuc85J0=
-github.com/giantswarm/app/v3 v3.3.1-0.20201125171539-804e2ceca77c/go.mod h1:WAPynam+MGDQ6mOnbW51omef+2eubgEYBCZYnB3BPcI=
+github.com/giantswarm/app/v3 v3.3.1-0.20201126093846-304e2ba5593a h1:44x0QOsund5XsKmJVv2t63Haah6SAJcTlOfLZzW4+/U=
+github.com/giantswarm/app/v3 v3.3.1-0.20201126093846-304e2ba5593a/go.mod h1:WAPynam+MGDQ6mOnbW51omef+2eubgEYBCZYnB3BPcI=
 github.com/giantswarm/appcatalog v0.2.7 h1:SVD1OH/C5zEP8TaeS3L9t8+lVcfaRZhwY98sn8v9lYs=
 github.com/giantswarm/appcatalog v0.2.7/go.mod h1:WHO5lJvcuwzToxxHPdiX9CVxvMsmP8YZfjoo4E/NTLs=
 github.com/giantswarm/apptest v0.5.0 h1:WGHEe5UDO9Rtn61s7/Osh/pF17JXThuc4JXyzPYeHJ0=

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions/v3 v3.4.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
 github.com/giantswarm/apiextensions/v3 v3.8.0 h1:gRqlNE62k49EdXYKBaShH0jkFBoOuGPxIgEnD5SZCx4=
 github.com/giantswarm/apiextensions/v3 v3.8.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/app/v3 v3.3.0 h1:Mpwc3+dHZKGTNl3y50F6QjVbiBQrgpZGTZfvax+xZKE=
-github.com/giantswarm/app/v3 v3.3.0/go.mod h1:1+kDyJBXp127yVXTdqfgWfGp50V4LkIq1lSDXBizICk=
+github.com/giantswarm/app/v3 v3.3.1-0.20201125171539-804e2ceca77c h1:Znj4g0fMfLWzUzLD/8NuUsMBXBmO3osjvXtqFuc85J0=
+github.com/giantswarm/app/v3 v3.3.1-0.20201125171539-804e2ceca77c/go.mod h1:WAPynam+MGDQ6mOnbW51omef+2eubgEYBCZYnB3BPcI=
 github.com/giantswarm/appcatalog v0.2.7 h1:SVD1OH/C5zEP8TaeS3L9t8+lVcfaRZhwY98sn8v9lYs=
 github.com/giantswarm/appcatalog v0.2.7/go.mod h1:WHO5lJvcuwzToxxHPdiX9CVxvMsmP8YZfjoo4E/NTLs=
 github.com/giantswarm/apptest v0.5.0 h1:WGHEe5UDO9Rtn61s7/Osh/pF17JXThuc4JXyzPYeHJ0=
@@ -348,6 +348,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.3 h1:x95R7cp+rSeeqAMI2knLtQ0DKlaBhv2NrtrOvafPHRo=
+github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions/v3 v3.4.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
 github.com/giantswarm/apiextensions/v3 v3.8.0 h1:gRqlNE62k49EdXYKBaShH0jkFBoOuGPxIgEnD5SZCx4=
 github.com/giantswarm/apiextensions/v3 v3.8.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/app/v3 v3.3.1-0.20201126093846-304e2ba5593a h1:44x0QOsund5XsKmJVv2t63Haah6SAJcTlOfLZzW4+/U=
-github.com/giantswarm/app/v3 v3.3.1-0.20201126093846-304e2ba5593a/go.mod h1:WAPynam+MGDQ6mOnbW51omef+2eubgEYBCZYnB3BPcI=
+github.com/giantswarm/app/v3 v3.3.1-0.20201126102224-e38557e5be74 h1:BfftUBSl8wA99FWNZUkA8wlCRbGuFJ0ks0YHkbGsYsU=
+github.com/giantswarm/app/v3 v3.3.1-0.20201126102224-e38557e5be74/go.mod h1:WAPynam+MGDQ6mOnbW51omef+2eubgEYBCZYnB3BPcI=
 github.com/giantswarm/appcatalog v0.2.7 h1:SVD1OH/C5zEP8TaeS3L9t8+lVcfaRZhwY98sn8v9lYs=
 github.com/giantswarm/appcatalog v0.2.7/go.mod h1:WHO5lJvcuwzToxxHPdiX9CVxvMsmP8YZfjoo4E/NTLs=
 github.com/giantswarm/apptest v0.5.0 h1:WGHEe5UDO9Rtn61s7/Osh/pF17JXThuc4JXyzPYeHJ0=

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions/v3 v3.4.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
 github.com/giantswarm/apiextensions/v3 v3.8.0 h1:gRqlNE62k49EdXYKBaShH0jkFBoOuGPxIgEnD5SZCx4=
 github.com/giantswarm/apiextensions/v3 v3.8.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/app/v3 v3.3.1-0.20201126102224-e38557e5be74 h1:BfftUBSl8wA99FWNZUkA8wlCRbGuFJ0ks0YHkbGsYsU=
-github.com/giantswarm/app/v3 v3.3.1-0.20201126102224-e38557e5be74/go.mod h1:WAPynam+MGDQ6mOnbW51omef+2eubgEYBCZYnB3BPcI=
+github.com/giantswarm/app/v3 v3.5.0 h1:/L8CFLKYo4Fx9yv98XE4qLWKD04jUFleekhPoDLUlhs=
+github.com/giantswarm/app/v3 v3.5.0/go.mod h1:WAPynam+MGDQ6mOnbW51omef+2eubgEYBCZYnB3BPcI=
 github.com/giantswarm/appcatalog v0.3.1 h1:7okCzHePYOpb2hKrfIcvEKk2/yeazyQJWZglHn+Y870=
 github.com/giantswarm/appcatalog v0.3.1/go.mod h1:cjOuCqi8gWudFY0ogbp4ukSV4Vff6kfInR9VdrX+7yI=
 github.com/giantswarm/apptest v0.7.1 h1:F3cY//vScE/djHTGGysbAR9xAiDUcw0WzMTR9zjmnBs=

--- a/pkg/app/mutate_app.go
+++ b/pkg/app/mutate_app.go
@@ -10,6 +10,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/app-admission-controller/pkg/mutator"
 )
@@ -116,6 +118,12 @@ func (m *Mutator) mutateConfig(ctx context.Context, app v1alpha1.App) ([]mutator
 		return nil, nil
 	}
 
+	// Return early if values configmap not found.
+	_, err := m.k8sClient.K8sClient().CoreV1().ConfigMaps(app.Namespace).Get(ctx, key.ClusterConfigMapName(app), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+
 	// If there is no secret then create a patch for the config block.
 	if key.AppSecretName(app) == "" && key.AppSecretNamespace(app) == "" {
 		result = append(result, mutator.PatchAdd("/spec/config", map[string]string{}))
@@ -139,6 +147,12 @@ func (m *Mutator) mutateKubeConfig(ctx context.Context, app v1alpha1.App) ([]mut
 
 	// Return early if either field is set.
 	if key.KubeConfigSecretName(app) != "" || key.KubeConfigSecretNamespace(app) != "" {
+		return nil, nil
+	}
+
+	// Return early if kubeconfig not found.
+	_, err := m.k8sClient.K8sClient().CoreV1().Secrets(app.Namespace).Get(ctx, key.ClusterKubeConfigSecretName(app), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#11656

Checks that the cluster values and kubeconfig exist before defaulting them. This fixes a bug when creating app CRs in the giantswarm namespace or other namespaces that don't have these resources.


