### PR TITLE
Delete unnecessary deletion timestamp check

### DIFF
--- a/pkg/app/mutate_app.go
+++ b/pkg/app/mutate_app.go
@@ -71,13 +71,6 @@ func (m *Mutator) Mutate(request *v1beta1.AdmissionRequest) ([]mutator.PatchOper
 
 	m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("mutating app %#q in namespace %#q", appNewCR.Name, appNewCR.Namespace))
 
-	// We check the deletion timestamp because app CRs may be deleted by
-	// deleting the namespace they belong to.
-	if !appNewCR.DeletionTimestamp.IsZero() {
-		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("admitted deletion of app %#q in namespace %#q", appNewCR.Name, appNewCR.Namespace))
-		return nil, nil
-	}
-
 	result, err := m.MutateApp(ctx, *appNewCR)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -82,13 +82,6 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 
 	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("validating app %#q in namespace %#q", app.Name, app.Namespace))
 
-	// We check the deletion timestamp because app CRs may be deleted by
-	// deleting the namespace they belong to.
-	if !app.DeletionTimestamp.IsZero() {
-		v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("admitted deletion of app %#q in namespace %#q", app.Name, app.Namespace))
-		return true, nil
-	}
-
 	ver, err := semver.NewVersion(key.VersionLabel(app))
 	if err != nil {
 		v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("skipping validation of app %#q in namespace %#q due to version label %#q", app.Name, app.Namespace, key.VersionLabel(app)))


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14993

We already have this (below) specified in the webhook configurations so
delete events are not dispatched to the mutator/validator.

        operations:
          - CREATE
          - UPDATE
