### PR TITLE
bump cert-manager apiversion to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update cert apiVersion to v1.
+
 ## [0.3.0] - 2021-01-11
 
 ### Added

--- a/helm/app-admission-controller/templates/certificate.yaml
+++ b/helm/app-admission-controller/templates/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "resource.default.name"  . }}-certificates


### PR DESCRIPTION
We need to update cert manager to v1 otherwise we might also run into issues like kiam
see https://github.com/giantswarm/kiam-app/pull/63

CPs have cert-manager-app-2.3.0 (cert-manager v1.0.2), so GA APIs can be used.

## Checklist

- [x] Update changelog in CHANGELOG.md.