### PR TITLE
Don't mutate .spec.config if its a management cluster app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't default `.spec.config` if app is a Management Cluster app.
+
 ## [0.5.1] - 2021-02-17
 
 ### Fixed

--- a/pkg/app/mutate_app.go
+++ b/pkg/app/mutate_app.go
@@ -193,6 +193,11 @@ func (m *Mutator) mutateConfig(ctx context.Context, app v1alpha1.App) ([]mutator
 		return nil, nil
 	}
 
+	// Return early if app is a Management Cluster app.
+	if key.VersionLabel(app) == uniqueAppCRVersion {
+		return nil, nil
+	}
+
 	// If there is no secret then create a patch for the config block.
 	if key.AppSecretName(app) == "" && key.AppSecretNamespace(app) == "" {
 		result = append(result, mutator.PatchAdd("/spec/config", map[string]string{}))

--- a/pkg/app/mutate_app.go
+++ b/pkg/app/mutate_app.go
@@ -187,14 +187,14 @@ func (m *Mutator) mutateConfig(ctx context.Context, app v1alpha1.App) ([]mutator
 		return nil, nil
 	}
 
-	// Return early if values configmap not found.
-	_, err := m.k8sClient.K8sClient().CoreV1().ConfigMaps(app.Namespace).Get(ctx, key.ClusterConfigMapName(app), metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
+	// Return early if app is a Management Cluster app.
+	if key.VersionLabel(app) == uniqueAppCRVersion {
 		return nil, nil
 	}
 
-	// Return early if app is a Management Cluster app.
-	if key.VersionLabel(app) == uniqueAppCRVersion {
+	// Return early if values configmap not found.
+	_, err := m.k8sClient.K8sClient().CoreV1().ConfigMaps(app.Namespace).Get(ctx, key.ClusterConfigMapName(app), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14163

For the app-operator app CR we don't want to default .spec.config.configMap.

```yaml
$ k -n 6z2ik get app app-operator-6z2ik -o yaml | k neat

apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  annotations:
    chart-operator.giantswarm.io/force-helm-upgrade: "false"
  labels:
    app-operator.giantswarm.io/version: 0.0.0
    app.kubernetes.io/name: app-operator
    config-controller.giantswarm.io/version: 0.0.0
    giantswarm.io/cluster: 6z2ik
    giantswarm.io/managed-by: cluster-operator
    giantswarm.io/organization: giantswarm
    giantswarm.io/service-type: managed
  name: app-operator-6z2ik
  namespace: 6z2ik
spec:
  catalog: control-plane-catalog
  kubeConfig:
    inCluster: true
  name: app-operator
  namespace: 6z2ik
  version: 4.0.0
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
