### PR TITLE
Support defaulting kubeconfig for CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for defaulting the kubeconfig secret for CAPI clusters.
+
 ### Fixed
 
 - Don't restrict user values configmap name for NGINX Ingress Controller

--- a/helm/app-admission-controller/templates/rbac.yaml
+++ b/helm/app-admission-controller/templates/rbac.yaml
@@ -26,6 +26,7 @@ rules:
       - secrets
     verbs:
       - "get"
+      - "list"
   - apiGroups:
       - ""
     resources:

--- a/pkg/app/mutate_app.go
+++ b/pkg/app/mutate_app.go
@@ -261,6 +261,10 @@ func (m *Mutator) mutateLabels(ctx context.Context, app v1alpha1.App, appVersion
 
 func findKubeConfigNamespace(ctx context.Context, k8sClient kubernetes.Interface, appNamespace, kubeConfigName string) (string, error) {
 	_, err := k8sClient.CoreV1().Secrets(appNamespace).Get(ctx, kubeConfigName, metav1.GetOptions{})
+	if err == nil {
+		// kubeconfig is in the same namespace as the app CR.
+		return appNamespace, nil
+	}
 	if apierrors.IsNotFound(err) {
 		// If its not in the app CR namespace this may be a CAPI cluster.
 		lo := metav1.ListOptions{
@@ -277,13 +281,10 @@ func findKubeConfigNamespace(ctx context.Context, k8sClient kubernetes.Interface
 				return secret.Namespace, nil
 			}
 		}
-
-		// Return empty as we can't find a kubeconfig.
-		return "", nil
 	}
 
-	// kubeconfig is in the same namespace as the app CR.
-	return appNamespace, nil
+	// Empty return as we can't find a kubeconfig.
+	return "", nil
 }
 
 func getChartOperatorAppVersion(ctx context.Context, g8sClient versioned.Interface, namespace string) (string, error) {

--- a/pkg/app/mutate_app.go
+++ b/pkg/app/mutate_app.go
@@ -221,7 +221,7 @@ func (m *Mutator) mutateKubeConfig(ctx context.Context, app v1alpha1.App) ([]mut
 		return nil, nil
 	}
 
-	kubeConfigNamespace, err := findKubeConfigNamespace(ctx, m.k8sClient.K8sClient(), app.Namespace, key.KubeConfigSecretName(app))
+	kubeConfigNamespace, err := findKubeConfigNamespace(ctx, m.k8sClient.K8sClient(), app.Namespace, key.ClusterKubeConfigSecretName(app))
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/pkg/app/mutate_app.go
+++ b/pkg/app/mutate_app.go
@@ -262,25 +262,35 @@ func (m *Mutator) mutateLabels(ctx context.Context, app v1alpha1.App, appVersion
 func findKubeConfigNamespace(ctx context.Context, k8sClient kubernetes.Interface, appNamespace, kubeConfigName string) (string, error) {
 	// Check for kubeconfig in the same namespace as the app CR.
 	_, err := k8sClient.CoreV1().Secrets(appNamespace).Get(ctx, kubeConfigName, metav1.GetOptions{})
+
+	fmt.Printf("GETTING KUBECONFIG %s/%s\n", appNamespace, kubeConfigName)
+
 	if apierrors.IsNotFound(err) {
 		// If its not found this may be a CAPI cluster.
 		lo := metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=%s", "cluster.x-k8s.io/cluster-name", appNamespace),
 		}
+
+		fmt.Printf("LISTING NAMESPACES\n")
+
 		secrets, err := k8sClient.CoreV1().Secrets(metav1.NamespaceAll).List(ctx, lo)
 		if err != nil {
 			return "", microerror.Mask(err)
 		}
 
 		for _, secret := range secrets.Items {
+			fmt.Printf("FOUND SECRET %s/%s\n", secret.Namespace, secret.Name)
 			if secret.Name == kubeConfigName {
+				fmt.Printf("RETURN NAMESPACE %s\n", secret.Namespace)
 				return secret.Namespace, nil
 			}
 		}
 
+		fmt.Printf("RETURN EMPTY\n")
 		return "", nil
 	}
 
+	fmt.Printf("RETURN NAMESPACE %s\n", appNamespace)
 	return appNamespace, nil
 }
 

--- a/pkg/app/mutate_app_test.go
+++ b/pkg/app/mutate_app_test.go
@@ -49,7 +49,14 @@ func Test_MutateApp(t *testing.T) {
 					Name:      "kiam",
 					Namespace: "kube-system",
 					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						Context: v1alpha1.AppSpecKubeConfigContext{
+							Name: "eggs2",
+						},
 						InCluster: false,
+						Secret: v1alpha1.AppSpecKubeConfigSecret{
+							Namespace: "eggs2",
+							Name:      "eggs2-kubeconfig",
+						},
 					},
 					Version: "1.4.0",
 				},
@@ -73,13 +80,6 @@ func Test_MutateApp(t *testing.T) {
 				mutator.PatchAdd("/spec/config/configMap", map[string]string{
 					"namespace": "eggs2",
 					"name":      "eggs2-cluster-values",
-				}),
-				mutator.PatchAdd("/spec/kubeConfig/context", map[string]string{
-					"name": "eggs2",
-				}),
-				mutator.PatchAdd("/spec/kubeConfig/secret", map[string]string{
-					"namespace": "eggs2",
-					"name":      "eggs2-kubeconfig",
 				}),
 			},
 		},

--- a/pkg/app/mutate_app_test.go
+++ b/pkg/app/mutate_app_test.go
@@ -49,14 +49,7 @@ func Test_MutateApp(t *testing.T) {
 					Name:      "kiam",
 					Namespace: "kube-system",
 					KubeConfig: v1alpha1.AppSpecKubeConfig{
-						Context: v1alpha1.AppSpecKubeConfigContext{
-							Name: "eggs2",
-						},
 						InCluster: false,
-						Secret: v1alpha1.AppSpecKubeConfigSecret{
-							Namespace: "eggs2",
-							Name:      "eggs2-kubeconfig",
-						},
 					},
 					Version: "1.4.0",
 				},
@@ -80,6 +73,13 @@ func Test_MutateApp(t *testing.T) {
 				mutator.PatchAdd("/spec/config/configMap", map[string]string{
 					"namespace": "eggs2",
 					"name":      "eggs2-cluster-values",
+				}),
+				mutator.PatchAdd("/spec/kubeConfig/context", map[string]string{
+					"name": "eggs2",
+				}),
+				mutator.PatchAdd("/spec/kubeConfig/secret", map[string]string{
+					"namespace": "eggs2",
+					"name":      "eggs2-kubeconfig",
 				}),
 			},
 		},


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/16742

Fixes problem found by @calvix with using `kubectl gs template app` with CAPI clusters.

See https://gigantic.slack.com/archives/CQZA6GGAY/p1631267306035400


## Checklist

- [x] Update changelog in CHANGELOG.md.
