### PR TITLE
Skip validation of app dependencies when managed-by label equals flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Skip validation of configmap and secret names when `giantswarm.io/managedby`
+label is set to flux.
+
 ## [0.12.0] - 2021-09-13
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions/v3 v3.38.0
-	github.com/giantswarm/app/v5 v5.4.1-0.20211124162558-f489a574f809
+	github.com/giantswarm/app/v5 v5.4.1-0.20211124163150-d8556da8f90b
 	github.com/giantswarm/apptest v0.12.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.12.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions/v3 v3.38.0
-	github.com/giantswarm/app/v5 v5.4.1-0.20211124163150-d8556da8f90b
+	github.com/giantswarm/app/v5 v5.5.0
 	github.com/giantswarm/apptest v0.12.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.12.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions/v3 v3.38.0
-	github.com/giantswarm/app/v5 v5.4.0
+	github.com/giantswarm/app/v5 v5.4.1-0.20211124162558-f489a574f809
 	github.com/giantswarm/apptest v0.12.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -182,10 +182,8 @@ github.com/giantswarm/apiextensions/v3 v3.32.0/go.mod h1:PcU7LAi0E8lOXoPp2wD7AY/
 github.com/giantswarm/apiextensions/v3 v3.38.0 h1:KdELD0Pd5aSGW5dVAOD579Hj46zcBNBvtrCGBf8ceOQ=
 github.com/giantswarm/apiextensions/v3 v3.38.0/go.mod h1:JgJfW2MjWKTAXfJ77rMcmKjVl3blvGSBWy43SVrpHY0=
 github.com/giantswarm/app/v5 v5.2.2/go.mod h1:2JiVuuz/uQ+L33nxmyAv+PJanq8oeEGuVA6mA0396Fk=
-github.com/giantswarm/app/v5 v5.4.1-0.20211124161307-c813d85040be h1:kUHBui0CH6TLtolTrGDC8vgtQPeaXN82arahM24DOY0=
-github.com/giantswarm/app/v5 v5.4.1-0.20211124161307-c813d85040be/go.mod h1:OmzlQWzZvo6xn2bG3/9/MAW0YhWu5FALtizYUGbZcEc=
-github.com/giantswarm/app/v5 v5.4.1-0.20211124162558-f489a574f809 h1:JnoFVUpIWN1gzDYDHxQIaAKkRvCFD8BncBi8KJUfnW8=
-github.com/giantswarm/app/v5 v5.4.1-0.20211124162558-f489a574f809/go.mod h1:OmzlQWzZvo6xn2bG3/9/MAW0YhWu5FALtizYUGbZcEc=
+github.com/giantswarm/app/v5 v5.4.1-0.20211124163150-d8556da8f90b h1:VXWDeCsp3tkcOpXIsGLjrBiO6Rr1iuVcMqbd2Sxhyt0=
+github.com/giantswarm/app/v5 v5.4.1-0.20211124163150-d8556da8f90b/go.mod h1:OmzlQWzZvo6xn2bG3/9/MAW0YhWu5FALtizYUGbZcEc=
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v0.12.0 h1:iKqUuhUamy9SaONo18/9J+dcuxg3qr3Y/UfXeVv3uMk=

--- a/go.sum
+++ b/go.sum
@@ -179,12 +179,13 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions/v3 v3.30.0/go.mod h1:PcU7LAi0E8lOXoPp2wD7AY/AOtp6sN03cnQuBZGAksg=
 github.com/giantswarm/apiextensions/v3 v3.32.0/go.mod h1:PcU7LAi0E8lOXoPp2wD7AY/AOtp6sN03cnQuBZGAksg=
-github.com/giantswarm/apiextensions/v3 v3.35.0/go.mod h1:uV8pzwVdUlzvrC9WZGb6z0koSNSampo3nLFSDW3mukA=
 github.com/giantswarm/apiextensions/v3 v3.38.0 h1:KdELD0Pd5aSGW5dVAOD579Hj46zcBNBvtrCGBf8ceOQ=
 github.com/giantswarm/apiextensions/v3 v3.38.0/go.mod h1:JgJfW2MjWKTAXfJ77rMcmKjVl3blvGSBWy43SVrpHY0=
 github.com/giantswarm/app/v5 v5.2.2/go.mod h1:2JiVuuz/uQ+L33nxmyAv+PJanq8oeEGuVA6mA0396Fk=
-github.com/giantswarm/app/v5 v5.4.0 h1:H2wY3SMMKp2ivrt5FtOzd8nQiA2Jq7YwJWfdmvQybUk=
-github.com/giantswarm/app/v5 v5.4.0/go.mod h1:xnbfQm/H5zlY813NGMyzj3h4/TlAvpDyJYioYd2b1PI=
+github.com/giantswarm/app/v5 v5.4.1-0.20211124161307-c813d85040be h1:kUHBui0CH6TLtolTrGDC8vgtQPeaXN82arahM24DOY0=
+github.com/giantswarm/app/v5 v5.4.1-0.20211124161307-c813d85040be/go.mod h1:OmzlQWzZvo6xn2bG3/9/MAW0YhWu5FALtizYUGbZcEc=
+github.com/giantswarm/app/v5 v5.4.1-0.20211124162558-f489a574f809 h1:JnoFVUpIWN1gzDYDHxQIaAKkRvCFD8BncBi8KJUfnW8=
+github.com/giantswarm/app/v5 v5.4.1-0.20211124162558-f489a574f809/go.mod h1:OmzlQWzZvo6xn2bG3/9/MAW0YhWu5FALtizYUGbZcEc=
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v0.12.0 h1:iKqUuhUamy9SaONo18/9J+dcuxg3qr3Y/UfXeVv3uMk=
@@ -196,7 +197,6 @@ github.com/giantswarm/cluster-api v0.3.10-gs/go.mod h1:878STePVJcBNDYFY2eCsLuHXW
 github.com/giantswarm/k8sclient/v5 v5.12.0 h1:oG5k7LLqMT+OaR/jMqOAQMTCpv5OdwjcJhFYGdIPThQ=
 github.com/giantswarm/k8sclient/v5 v5.12.0/go.mod h1:KXRSG1t+XBDsXx089Jp9agMjQ4xEIWywJUchAZ2OQ6c=
 github.com/giantswarm/k8smetadata v0.3.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
-github.com/giantswarm/k8smetadata v0.4.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.6.0 h1:L3opjzcNzetPacI4zOcYxDAvp6ssM/QLfuXZTQ5Otyo=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
@@ -206,6 +206,7 @@ github.com/giantswarm/micrologger v0.3.1/go.mod h1:PjAgtcJ922ZMX/Aa05IPi0bdYvOj2
 github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
 github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=
 github.com/giantswarm/to v0.3.0/go.mod h1:RTRtw+Dyk6YqoiNBOGLO981BqhibtVwogdaFIMO1y/A=
+github.com/giantswarm/to v0.4.0/go.mod h1:RTRtw+Dyk6YqoiNBOGLO981BqhibtVwogdaFIMO1y/A=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/giantswarm/apiextensions/v3 v3.32.0/go.mod h1:PcU7LAi0E8lOXoPp2wD7AY/
 github.com/giantswarm/apiextensions/v3 v3.38.0 h1:KdELD0Pd5aSGW5dVAOD579Hj46zcBNBvtrCGBf8ceOQ=
 github.com/giantswarm/apiextensions/v3 v3.38.0/go.mod h1:JgJfW2MjWKTAXfJ77rMcmKjVl3blvGSBWy43SVrpHY0=
 github.com/giantswarm/app/v5 v5.2.2/go.mod h1:2JiVuuz/uQ+L33nxmyAv+PJanq8oeEGuVA6mA0396Fk=
-github.com/giantswarm/app/v5 v5.4.1-0.20211124163150-d8556da8f90b h1:VXWDeCsp3tkcOpXIsGLjrBiO6Rr1iuVcMqbd2Sxhyt0=
-github.com/giantswarm/app/v5 v5.4.1-0.20211124163150-d8556da8f90b/go.mod h1:OmzlQWzZvo6xn2bG3/9/MAW0YhWu5FALtizYUGbZcEc=
+github.com/giantswarm/app/v5 v5.5.0 h1:290c/M0Q3KwD+MMK9gwsBJrydSBkOHqMDvDHmwiljIg=
+github.com/giantswarm/app/v5 v5.5.0/go.mod h1:ZwY4Bub/IOUn1VEvaMkBLD2eeWZCW0/dPO+ngANLRYM=
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v0.12.0 h1:iKqUuhUamy9SaONo18/9J+dcuxg3qr3Y/UfXeVv3uMk=
@@ -764,8 +764,9 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1 h1:B333XXssMuKQeBwiNODx4TupZy7bf4sxFZnN2ZOcvUE=
 golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/helm/app-admission-controller/Chart.yaml
+++ b/helm/app-admission-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: app-admission-controller
-description: A Helm chart for app-admission-controller
+description: app-admission-controller validates and defaults app CRs
 home: https://github.com/giantswarm/app-admission-controller
 version: [[ .Version ]]
 appVersion: [[ .AppVersion ]]

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -124,7 +124,7 @@ func (v *Validator) Validate(request *admissionv1.AdmissionRequest) (bool, error
 	}
 
 	if key.IsManagedByFlux(app, project.Name()) {
-		v.logger.Debugf(ctx, "skipping validation of '%s/%s' app dependencies due to '%s=%s'", app.Namespace, app.Name, label.ManagedBy, key.ManagedByLabel(app))
+		v.logger.Debugf(ctx, "skipping validation of app '%s/%s' dependencies due to '%s=%s' label", app.Namespace, app.Name, label.ManagedBy, key.ManagedByLabel(app))
 		return true, nil
 	}
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,29 @@
+package project
+
+var (
+	description = "app-admission-controller validates and defaults app CRs."
+	gitSHA      = "n/a"
+	name        = "app-admission-controller"
+	source      = "https://github.com/giantswarm/app-admission-controller"
+	version     = "0.12.1-dev"
+)
+
+func Description() string {
+	return description
+}
+
+func GitSHA() string {
+	return gitSHA
+}
+
+func Name() string {
+	return name
+}
+
+func Source() string {
+	return source
+}
+
+func Version() string {
+	return version
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19700

Related to giantswarm/workload-clusters-fleet-demo#1

We can simplify our Flux setup to include user values configmaps and secrets in the same directory as the app CR.

To do this we loosen the validation in app-admission-controller if the label `giantswarm.io/managed-by` is set to `flux`.
We keep the logic in the validation resource in app-operator which sets the app CR status.

## Checklist

- [x] Update changelog in CHANGELOG.md.
