### PR TITLE
Move conditional validation on the`managed-by` label to the `github.com/giantswarm/app` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
+### Fixed
 
 - Remove `key.IsManagedByFlux` check and move it to `github.com/giantswarm/app` package.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `key.IsManagedByFlux` check and move it to `github.com/giantswarm/app` package.
+
 ## [0.15.0] - 2022-01-13
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions-application v0.3.0
-	github.com/giantswarm/app/v6 v6.5.0
+	github.com/giantswarm/app/v6 v6.5.1
 	github.com/giantswarm/apptest v1.0.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v6 v6.1.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions-application v0.3.0
-	github.com/giantswarm/app/v6 v6.4.1-0.20220118182959-bcbcc43d4756
+	github.com/giantswarm/app/v6 v6.4.1-0.20220119154624-a75788afb6d1
 	github.com/giantswarm/apptest v1.0.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v6 v6.1.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions-application v0.3.0
-	github.com/giantswarm/app/v6 v6.4.1-0.20220119154624-a75788afb6d1
+	github.com/giantswarm/app/v6 v6.5.0
 	github.com/giantswarm/apptest v1.0.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v6 v6.1.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions-application v0.3.0
-	github.com/giantswarm/app/v6 v6.4.0
+	github.com/giantswarm/app/v6 v6.4.1-0.20220118182959-bcbcc43d4756
 	github.com/giantswarm/apptest v1.0.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v6 v6.1.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/giantswarm/micrologger v0.6.0
 	github.com/google/go-cmp v0.5.7
 	github.com/prometheus/client_golang v1.12.0
-	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.21.4
 	k8s.io/apimachinery v0.21.4

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/giantswarm/apiextensions-application v0.1.0/go.mod h1:O6mg+EdXC9CyTLg
 github.com/giantswarm/apiextensions-application v0.3.0 h1:U1dQPNo7DXdH4VAFXdPhAWZNI98XE4nMonaUFhclIqo=
 github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/app/v6 v6.0.0/go.mod h1:oq9qBedss6ctqFAyEgLkBwjKAik+D5C+0LDNQOicLGA=
-github.com/giantswarm/app/v6 v6.5.0 h1:M5yZ0gHrprc4iem91xRmmPKPwwTP3WgQT0ofDgZFQcE=
-github.com/giantswarm/app/v6 v6.5.0/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
+github.com/giantswarm/app/v6 v6.5.1 h1:pmBR7/La2CvnWBHRkfc1jyy3CyIbKvSAjxb7GUoBloo=
+github.com/giantswarm/app/v6 v6.5.1/go.mod h1:mCikT+N+d+jDDNQJx/b9ee/BaGfJMJ9UY0Wpxw8qv7k=
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v1.0.0 h1:M4O9A/yOMrsrUgR5rfSSFY8rlr3eGo2/8ztnsAEiupw=

--- a/go.sum
+++ b/go.sum
@@ -174,13 +174,12 @@ github.com/giantswarm/apiextensions-application v0.1.0/go.mod h1:O6mg+EdXC9CyTLg
 github.com/giantswarm/apiextensions-application v0.3.0 h1:U1dQPNo7DXdH4VAFXdPhAWZNI98XE4nMonaUFhclIqo=
 github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/app/v6 v6.0.0/go.mod h1:oq9qBedss6ctqFAyEgLkBwjKAik+D5C+0LDNQOicLGA=
-<<<<<<< HEAD
-github.com/giantswarm/app/v6 v6.4.0 h1:vFAKysVuEjqFQMCZKrBgwlBJ64W1/KVFtUE0u46tpKQ=
-github.com/giantswarm/app/v6 v6.4.0/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
-=======
 github.com/giantswarm/app/v6 v6.4.1-0.20220118182959-bcbcc43d4756 h1:sIZPZR7ubR/cg3FXFL4VNJ30DeRoug87O48nZLISO8U=
 github.com/giantswarm/app/v6 v6.4.1-0.20220118182959-bcbcc43d4756/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
->>>>>>> 9aa08c0 (Removing checking for Flux label)
+=======
+github.com/giantswarm/app/v6 v6.4.1-0.20220119154624-a75788afb6d1 h1:scN21+Tyb74dSKEo2Hbe3/8XynbdBZXwyiLPufdtPyM=
+github.com/giantswarm/app/v6 v6.4.1-0.20220119154624-a75788afb6d1/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
+>>>>>>> 3fc841e (Bumping deps)
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v1.0.0 h1:M4O9A/yOMrsrUgR5rfSSFY8rlr3eGo2/8ztnsAEiupw=

--- a/go.sum
+++ b/go.sum
@@ -174,12 +174,8 @@ github.com/giantswarm/apiextensions-application v0.1.0/go.mod h1:O6mg+EdXC9CyTLg
 github.com/giantswarm/apiextensions-application v0.3.0 h1:U1dQPNo7DXdH4VAFXdPhAWZNI98XE4nMonaUFhclIqo=
 github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/app/v6 v6.0.0/go.mod h1:oq9qBedss6ctqFAyEgLkBwjKAik+D5C+0LDNQOicLGA=
-github.com/giantswarm/app/v6 v6.4.1-0.20220118182959-bcbcc43d4756 h1:sIZPZR7ubR/cg3FXFL4VNJ30DeRoug87O48nZLISO8U=
-github.com/giantswarm/app/v6 v6.4.1-0.20220118182959-bcbcc43d4756/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
-=======
 github.com/giantswarm/app/v6 v6.4.1-0.20220119154624-a75788afb6d1 h1:scN21+Tyb74dSKEo2Hbe3/8XynbdBZXwyiLPufdtPyM=
 github.com/giantswarm/app/v6 v6.4.1-0.20220119154624-a75788afb6d1/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
->>>>>>> 3fc841e (Bumping deps)
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v1.0.0 h1:M4O9A/yOMrsrUgR5rfSSFY8rlr3eGo2/8ztnsAEiupw=

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/giantswarm/apiextensions-application v0.1.0/go.mod h1:O6mg+EdXC9CyTLg
 github.com/giantswarm/apiextensions-application v0.3.0 h1:U1dQPNo7DXdH4VAFXdPhAWZNI98XE4nMonaUFhclIqo=
 github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/app/v6 v6.0.0/go.mod h1:oq9qBedss6ctqFAyEgLkBwjKAik+D5C+0LDNQOicLGA=
-github.com/giantswarm/app/v6 v6.4.1-0.20220119154624-a75788afb6d1 h1:scN21+Tyb74dSKEo2Hbe3/8XynbdBZXwyiLPufdtPyM=
-github.com/giantswarm/app/v6 v6.4.1-0.20220119154624-a75788afb6d1/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
+github.com/giantswarm/app/v6 v6.5.0 h1:M5yZ0gHrprc4iem91xRmmPKPwwTP3WgQT0ofDgZFQcE=
+github.com/giantswarm/app/v6 v6.5.0/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v1.0.0 h1:M4O9A/yOMrsrUgR5rfSSFY8rlr3eGo2/8ztnsAEiupw=

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,13 @@ github.com/giantswarm/apiextensions-application v0.1.0/go.mod h1:O6mg+EdXC9CyTLg
 github.com/giantswarm/apiextensions-application v0.3.0 h1:U1dQPNo7DXdH4VAFXdPhAWZNI98XE4nMonaUFhclIqo=
 github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/app/v6 v6.0.0/go.mod h1:oq9qBedss6ctqFAyEgLkBwjKAik+D5C+0LDNQOicLGA=
+<<<<<<< HEAD
 github.com/giantswarm/app/v6 v6.4.0 h1:vFAKysVuEjqFQMCZKrBgwlBJ64W1/KVFtUE0u46tpKQ=
 github.com/giantswarm/app/v6 v6.4.0/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
+=======
+github.com/giantswarm/app/v6 v6.4.1-0.20220118182959-bcbcc43d4756 h1:sIZPZR7ubR/cg3FXFL4VNJ30DeRoug87O48nZLISO8U=
+github.com/giantswarm/app/v6 v6.4.1-0.20220118182959-bcbcc43d4756/go.mod h1:kqVk28i/32j/ngeqrDx4dBL4JX70ZO3tIp/cLfAfrUk=
+>>>>>>> 9aa08c0 (Removing checking for Flux label)
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v1.0.0 h1:M4O9A/yOMrsrUgR5rfSSFY8rlr3eGo2/8ztnsAEiupw=

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -62,8 +62,12 @@ func NewValidator(config ValidatorConfig) (*Validator, error) {
 			K8sClient: config.K8sClient.K8sClient(),
 			Logger:    config.Logger,
 
-			ProjectName:            project.Name(),
-			Provider:               config.Provider,
+			ProjectName: project.Name(),
+			Provider:    config.Provider,
+
+			// `ValidateResourcesExist` influences ConfigMaps and Secrets existence
+			// part of the validation. When `true` the `managed-by` labels
+			// are respected, otherwise these labels do not influence validation.
 			ValidateResourcesExist: true,
 		}
 		appValidator, err = validation.NewValidator(c)

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -9,7 +9,6 @@ import (
 	"github.com/giantswarm/app/v6/pkg/key"
 	"github.com/giantswarm/app/v6/pkg/validation"
 	"github.com/giantswarm/k8sclient/v6/pkg/k8sclient"
-	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -120,11 +119,6 @@ func (v *Validator) Validate(request *admissionv1.AdmissionRequest) (bool, error
 	// enabled for existing platform releases.
 	if key.VersionLabel(app) != uniqueAppCRVersion && ver.Major() < 3 {
 		v.logger.Debugf(ctx, "skipping validation of app %#q in namespace %#q due to version label %#q", app.Name, app.Namespace, key.VersionLabel(app))
-		return true, nil
-	}
-
-	if key.IsManagedByFlux(app, project.Name()) {
-		v.logger.Debugf(ctx, "skipping validation of app '%s/%s' dependencies due to '%s=%s' label", app.Namespace, app.Name, label.ManagedBy, key.ManagedByLabel(app))
 		return true, nil
 	}
 

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -65,10 +65,11 @@ func NewValidator(config ValidatorConfig) (*Validator, error) {
 			ProjectName: project.Name(),
 			Provider:    config.Provider,
 
-			// `ValidateResourcesExist` influences ConfigMaps and Secrets existence
-			// part of the validation. When `true` the `managed-by` labels
-			// are respected, otherwise these labels do not influence validation.
-			ValidateResourcesExist: true,
+			// `EnableManagedByLabel` enables skipping checks for
+			// ConfigMap and Secret existence when the `giantswarm.io/managed-by`
+			// label is present. This is used when app CRs are managed
+			// with gitops tools like flux.
+			EnableManagedByLabel: true,
 		}
 		appValidator, err = validation.NewValidator(c)
 		if err != nil {

--- a/pkg/app/validate_app.go
+++ b/pkg/app/validate_app.go
@@ -62,8 +62,9 @@ func NewValidator(config ValidatorConfig) (*Validator, error) {
 			K8sClient: config.K8sClient.K8sClient(),
 			Logger:    config.Logger,
 
-			ProjectName: project.Name(),
-			Provider:    config.Provider,
+			ProjectName:            project.Name(),
+			Provider:               config.Provider,
+			ValidateResourcesExist: true,
 		}
 		appValidator, err = validation.NewValidator(c)
 		if err != nil {


### PR DESCRIPTION
### Description

This PR removes `key.IsManagedByFlux` from the App Admission Controller in favor of the https://github.com/giantswarm/app/pull/200. This is to narrow down its scope.

### Examples

Some fields have been removed from examples for brevity.

#### How does it work now

1. This App CR get accepted due to the `managed-by: flux` label.

```yaml
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    giantswarm.io/managed-by: flux
  name: hello-world
  namespace: giantswarm
spec:
  ...
  userConfig:
    configMap:
      name: non-existing-hello-world-user-values
      namespace: giantswarm
```

2. This App CR does not get accepted due the missing `managed-by` label.

App CR:

```yaml
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: hello-world
  namespace: giantswarm
spec:
  ...
  userConfig:
    configMap:
      name: non-existing-hello-world-user-values
      namespace: giantswarm
```

Error:

```sh
Error from server: error when creating "appcr.yaml": admission webhook "apps.app-admission-controller.giantswarm.io" denied the request: validation error: configmap `non-existing-hello-world-user-values` in namespace `giantswarm` not found
```
3. Changing the `.spec.namespace` is blocked for Apps without the `managed-by` label.
 
App CR:

```yaml
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
  name: hello-world
  namespace: giantswarm
spec:
  catalog: giantswarm
  kubeConfig:
    inCluster: true
  name: hello-world-app
  namespace: giantswarm
  version: 0.1.0
```

Changing namespace to `kube-system` results in:

```sh
error: apps.application.giantswarm.io "hello-world" could not be patched: admission webhook "apps.app-admission-controller.giantswarm.io" denied the request: validation error: target namespace for app `hello-world` cannot be changed from `giantswarm` to `kube-system`
```

4. Changing the `.spec.namespace` works for Flux-managed Apps, but it should not, and it results in failed App status.

App CR:

```yaml
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
    giantswarm.io/managed-by: flux
  name: hello-world
  namespace: giantswarm
spec:
  catalog: giantswarm
  kubeConfig:
    inCluster: true
  name: hello-world-app
  namespace: giantswarm
  version: 0.1.0
```

Changing namespace to `kube-system` is accepted by the Admission Controller, but fails with status:

```sh
object already exists: (rendered manifests contain a resource that already exists. Unable to continue with install: PodSecurityPolicy "hello-world-psp" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "kube-system": current value is "giantswarm")
```

#### How does it work after 

Let's revisit the above examples.

1. Works the same.
2. Works the same.
3. Works the same.
4. Now changing the `.spec.namespace` is blocked as expected with the error:

```yaml
error: apps.application.giantswarm.io "hello-world" could not be patched: admission webhook "apps.app-admission-controller.giantswarm.io" denied the request: validation error: target namespace for app `hello-world` cannot be changed from `giantswarm` to `kube-system`
```

### Checklist

- [x] Update changelog in CHANGELOG.md.