### PR TITLE
Add pre-commit config for Go projects

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+MD013:
+  code_blocks: false
+  line_length: 120

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,0 @@
-MD013:
-  code_blocks: false
-  line_length: 120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,6 @@ repos:
       - id: shell-lint
         args: [ --format=json ]
 
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
-    hooks:
-        - id: markdownlint
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,5 @@ repos:
       - id: go-imports
         args: [ -local, github.com/giantswarm/app-admission-controller ]
       - id: golangci-lint
-        # do we want build?
-        # - id: go-build
         args: [ -E, gosec, -E, goconst, -E, vet ]
+      - id: go-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+minimum_pre_commit_version: '2.17'
+exclude: 'vendor'
+repos:
+  # shell scripts
+  - repo: git://github.com/detailyang/pre-commit-shell
+    rev: 1.0.5
+    hooks:
+      - id: shell-lint
+        args: [ --format=json ]
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.31.1
+    hooks:
+        - id: markdownlint
+
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v3.0.1
+    hooks:
+      - id: check-added-large-files
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: git://github.com/dnephin/pre-commit-golang
+    rev: v0.3.5
+    hooks:
+      - id: go-fmt
+      - id: go-mod-tidy
+      - id: go-imports
+      - id: go-vet
+      - id: go-build
+      - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
       - id: go-mod-tidy
       - id: go-imports
       - id: go-vet
+        args: [ -local, github.com/giantswarm/app-admission-controller ]
       - id: golangci-lint
         # do we want build?
         # - id: go-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
       - id: golangci-lint
-        args: [ -E, gosec, -E, goconst, -E, vet ]
+        args: [ -E, gosec, -E, goconst, -E, govet ]
       - id: go-imports
         args: [ -local, github.com/giantswarm/app-admission-controller ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 minimum_pre_commit_version: '2.17'
-exclude: 'vendor'
 repos:
   # shell scripts
   - repo: https://github.com/detailyang/pre-commit-shell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ minimum_pre_commit_version: '2.17'
 exclude: 'vendor'
 repos:
   # shell scripts
-  - repo: git://github.com/detailyang/pre-commit-shell
+  - repo: https://github.com/detailyang/pre-commit-shell
     rev: 1.0.5
     hooks:
       - id: shell-lint
@@ -13,8 +13,8 @@ repos:
     hooks:
         - id: markdownlint
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.0.1
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
     hooks:
       - id: check-added-large-files
       - id: check-docstring-first
@@ -25,12 +25,13 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
-  - repo: git://github.com/dnephin/pre-commit-golang
-    rev: v0.3.5
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.0
     hooks:
       - id: go-fmt
       - id: go-mod-tidy
       - id: go-imports
       - id: go-vet
-      - id: go-build
       - id: golangci-lint
+        # do we want build?
+        # - id: go-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,8 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
       - id: go-imports
-      - id: go-vet
         args: [ -local, github.com/giantswarm/app-admission-controller ]
       - id: golangci-lint
         # do we want build?
         # - id: go-build
+        args: [ -E, gosec, -E, goconst, -E, vet ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v4.1.0
     hooks:
       - id: check-added-large-files
-      - id: check-docstring-first
+      # check for unresolved merge conflicts
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
       - id: detect-private-key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,7 @@ repos:
     hooks:
       - id: go-fmt
       - id: go-mod-tidy
-      - id: go-imports
-        args: [ -local, github.com/giantswarm/app-admission-controller ]
       - id: golangci-lint
         args: [ -E, gosec, -E, goconst, -E, vet ]
-      - id: go-build
+      - id: go-imports
+        args: [ -local, github.com/giantswarm/app-admission-controller ]

--- a/docs/events.md
+++ b/docs/events.md
@@ -3,7 +3,7 @@
 
 At the end of each successful validation of an app CR, app-admission-controller checks the changes for the following fields and emits an event.
 
-- `.spec.version` 
+- `.spec.version`
 - `.spec.catalog`
 - `.spec.userConfig.configMap`
 - `.spec.userConfig.secret`
@@ -24,5 +24,5 @@ Events:
   ----    ------      ----   ----                      -------
   Normal  AppUpdated  3m2s   app-admission-controller  version has been changed to `1.1.0`
   Normal  AppUpdated  2m49s  app-admission-controller  version has been changed to `1.1.1`
-  Normal  AppUpdated  1s     app-admission-controller  appConfigMap has been resetted 
+  Normal  AppUpdated  1s     app-admission-controller  appConfigMap has been resetted
 ```

--- a/helm/app-admission-controller/templates/networkpolicy.yaml
+++ b/helm/app-admission-controller/templates/networkpolicy.yaml
@@ -22,4 +22,3 @@ spec:
   policyTypes:
   - Egress
   - Ingress
-


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20149

This PR adds a sample [pre-commit](https://pre-commit.com/) config for Go projects.

We'd like to get feedback on this before generating it via the github repo. Like we do already for [Python](https://github.com/giantswarm/github/blob/master/languages/python/.pre-commit-config.yaml). 

To try this out in your local dir install pre-commit https://pre-commit.com/#install and run

```
pre-commit install --install-hooks
pre-commit run -a
```

