### PR TITLE
Add workflow to run pre-commit

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/setup-python@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.17.7'
+        go-version: "1.17.7"
     - name: Install goimports
       run: |
         go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -22,5 +22,5 @@ jobs:
         GOLANGCI_LINT_VERSION: "v1.42.1"
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
+            sudo sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
     - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -19,7 +19,6 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
     - name: Install golangci-lint
       env:
-        GOPATH: "/go"
         GOLANGCI_LINT_VERSION: "v1.42.1"
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -17,4 +17,11 @@ jobs:
     - name: Install goimports
       run: |
         go install golang.org/x/tools/cmd/goimports@latest
+    - name: Install golangci-lint
+      env:
+        GOPATH: "/go"
+        GOLANGCI_LINT_VERSION: "v1.42.1"
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+            sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
     - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17.7'
+    - name: Install goimports
+      run: |
+        go install golang.org/x/tools/cmd/goimports@latest
+    - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
       - id: golangci-lint
-        args: [ -E, gosec, -E, goconst, -E, govet ]
+        args: [ -E, gosec, -E, goconst, ]
       - id: go-imports
         args: [ -local, github.com/giantswarm/app-admission-controller ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
       - id: golangci-lint
-        args: [ -E, gosec, -E, goconst, -E, govet, --timeout, 180s ]
+        # timeout is needed for CI
+        args: [ -E, gosec, -E, goconst, -E, govet, --timeout, 120s ]
       - id: go-imports
         args: [ -local, github.com/giantswarm/app-admission-controller ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
       - id: golangci-lint
-        args: [ -E, gosec, -E, goconst, ]
+        args: [ -E, gosec, -E, goconst ]
       - id: go-imports
         args: [ -local, github.com/giantswarm/app-admission-controller ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,7 @@ repos:
     hooks:
       - id: go-fmt
       - id: go-mod-tidy
+      - id: golangci-lint
+        args: [ -E, gosec, -E, goconst, -E, govet, --timeout, 180s ]
       - id: go-imports
         args: [ -local, github.com/giantswarm/app-admission-controller ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,5 @@ repos:
     hooks:
       - id: go-fmt
       - id: go-mod-tidy
-      - id: golangci-lint
-        args: [ -E, gosec, -E, goconst ]
       - id: go-imports
         args: [ -local, github.com/giantswarm/app-admission-controller ]


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20149

This PR adds a GitHub workflow to run pre-commit. This is easier than using Circle CI and means we can leave the current checks in place when pre-commit is not being used.

Next step will be generating the workflow via the github repo.


