### PR TITLE
Bump `giantswarm/app` library to `v6.13.0` that contains a new App CR validator for unique in-cluster app names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,4 +184,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `giantswarm/app` library to `v6.13.0` that contains a new App CR validator for unique in-cluster app names
+
 ## [0.17.2] - 2022-07-12
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions-application v0.5.1
-	github.com/giantswarm/app/v6 v6.12.1-0.20220825122921-347390ee991a
+	github.com/giantswarm/app/v6 v6.13.0
 	github.com/giantswarm/apptest v1.0.1
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v6 v6.1.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions-application v0.5.1
-	github.com/giantswarm/app/v6 v6.12.0
+	github.com/giantswarm/app/v6 v6.12.1-0.20220825122921-347390ee991a
 	github.com/giantswarm/apptest v1.0.1
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v6 v6.1.0

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLg
 github.com/giantswarm/apiextensions-application v0.5.1 h1:98R6TUCNegJmFyQIZ6MAFGLxAd0kyfIFbmq5lukcqJ4=
 github.com/giantswarm/apiextensions-application v0.5.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/app/v6 v6.5.1/go.mod h1:mCikT+N+d+jDDNQJx/b9ee/BaGfJMJ9UY0Wpxw8qv7k=
-github.com/giantswarm/app/v6 v6.12.0 h1:t+cfYQiIfu42jZqMBZKgw9loChkltsXF0HLbdoDDv+o=
-github.com/giantswarm/app/v6 v6.12.0/go.mod h1:ZU2PSxarYJNK53JtdsPJhexseyL595it8AjBCOB9SuA=
+github.com/giantswarm/app/v6 v6.12.1-0.20220825122921-347390ee991a h1:QjQaAdU35/eI+Ug32JWXUerPRKq7uOjSxiUFzyB433U=
+github.com/giantswarm/app/v6 v6.12.1-0.20220825122921-347390ee991a/go.mod h1:ZU2PSxarYJNK53JtdsPJhexseyL595it8AjBCOB9SuA=
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v1.0.1 h1:QqUpYih54e4AwW5z9HOgt5k/jVSsTU0pKjjnxZgsKZo=

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLg
 github.com/giantswarm/apiextensions-application v0.5.1 h1:98R6TUCNegJmFyQIZ6MAFGLxAd0kyfIFbmq5lukcqJ4=
 github.com/giantswarm/apiextensions-application v0.5.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/app/v6 v6.5.1/go.mod h1:mCikT+N+d+jDDNQJx/b9ee/BaGfJMJ9UY0Wpxw8qv7k=
-github.com/giantswarm/app/v6 v6.12.1-0.20220825122921-347390ee991a h1:QjQaAdU35/eI+Ug32JWXUerPRKq7uOjSxiUFzyB433U=
-github.com/giantswarm/app/v6 v6.12.1-0.20220825122921-347390ee991a/go.mod h1:ZU2PSxarYJNK53JtdsPJhexseyL595it8AjBCOB9SuA=
+github.com/giantswarm/app/v6 v6.13.0 h1:KC/duHT3Dp6VVslc7PRCL/kaSaDt1e8fAY4/mdlizQg=
+github.com/giantswarm/app/v6 v6.13.0/go.mod h1:ZU2PSxarYJNK53JtdsPJhexseyL595it8AjBCOB9SuA=
 github.com/giantswarm/appcatalog v0.6.0 h1:lJMmiPK2pyWQtOaLlBwq0Ut1XrMhcnGeA+3j4OMHyfU=
 github.com/giantswarm/appcatalog v0.6.0/go.mod h1:MaglaykZAeFukjpD/jVHrm/zZFwa9uusuN6BgT4NXpY=
 github.com/giantswarm/apptest v1.0.1 h1:QqUpYih54e4AwW5z9HOgt5k/jVSsTU0pKjjnxZgsKZo=


### PR DESCRIPTION
## Checklist

- [x] Update `app` library version when https://github.com/giantswarm/app/pull/257 gets released
- [x] Update changelog in CHANGELOG.md.

## Tests

Tested with the following App CRs.

```yaml
---
apiVersion: v1
data:
  values: |
    clusterName: a9q6m
    organization: giantswarm
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: security-pack-userconfig
  namespace: a9q6m
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
    giantswarm.io/cluster: a9q6m
  name: security-pack
  namespace: a9q6m
spec:
  catalog: giantswarm-playground
  kubeConfig:
    inCluster: true
  name: security-pack
  namespace: a9q6m
  userConfig:
    configMap:
      name: security-pack-userconfig
      namespace: a9q6m
  version: 0.6.0

```

and:

```yaml
---
apiVersion: v1
data:
  values: |
    clusterName: kc2a8
    organization: giantswarm
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: security-pack-userconfig
  namespace: kc2a8
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
    giantswarm.io/cluster: kc2a8
  name: security-pack
  namespace: kc2a8
spec:
  catalog: giantswarm-playground
  kubeConfig:
    inCluster: true
  name: security-pack
  namespace: kc2a8
  userConfig:
    configMap:
      name: security-pack-userconfig
      namespace: kc2a8
  version: 0.6.0
```

### Example output

```bash
$ k -n a9q6m apply -f security-pack-a9q6m.yaml
configmap/security-pack-userconfig created
app.application.giantswarm.io/security-pack created

$ k gs -n a9q6m get app security-pack
NAME            VERSION   LAST DEPLOYED   STATUS     NOTES
security-pack   0.6.0     3m23s           deployed

$ k -n kc2a8 apply -f security-pack-kc2a8.yaml
configmap/security-pack-userconfig created
Error from server: error when creating "security-pack-kc2a8.yaml": admission webhook "apps.app-admission-controller.giantswarm.io" denied the request: validation error: in-cluster apps must be given a unique name, found an app named `security-pack` as well in the `a9q6m` namespace
```

And the resulting logs in `app-admission-controller`:

```text
app-admission-controller-d8d78f547-z2dq2 app-admission-controller {"caller":"github.com/giantswarm/app-admission-controller/pkg/app/validate_app.go:165","level":"error","message":"rejected app `security-pack` in namespace `kc2a8`","stack":{"annotation":"in-cluster apps must be given a unique name, found an app named `security-pack` as well in the `a9q6m` namespace","kind":"validationError","stack":[{"file":"/go/pkg/mod/github.com/giantswarm/app/v6@v6.12.1-0.20220825122921-347390ee991a/pkg/validation/app.go","line":523},{"file":"/go/pkg/mod/github.com/giantswarm/app/v6@v6.12.1-0.20220825122921-347390ee991a/pkg/validation/app.go","line":92}]},"time":"2022-08-25T13:53:22.133755+00:00"}
```

Trying to apply this however will pass validation:

```yaml
---
apiVersion: v1
data:
  values: |
    clusterName: kc2a8
    organization: giantswarm
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: kc2a8-security-pack-userconfig
  namespace: kc2a8
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
    giantswarm.io/cluster: kc2a8
  name: kc2a8-security-pack
  namespace: kc2a8
spec:
  catalog: giantswarm-playground
  kubeConfig:
    inCluster: true
  name: security-pack
  namespace: kc2a8
  userConfig:
    configMap:
      name: kc2a8-security-pack-userconfig
      namespace: kc2a8
  version: 0.6.0
```
Output:

```bash
$ k -n kc2a8 apply -f security-pack-kc2a8.UNIQUE.yaml
configmap/kc2a8-security-pack-userconfig created
app.application.giantswarm.io/kc2a8-security-pack created
```
