### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.23.0] - 2023-11-17
 
 ### Changed
@@ -77,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `giantswarm/app` package to `v6.15.5`
 -
+
 ## [0.18.4] - 2023-03-09
 
 ### Changed

--- a/helm/app-admission-controller/values.yaml
+++ b/helm/app-admission-controller/values.yaml
@@ -6,7 +6,7 @@ image:
   tag: "[[ .Version ]]"
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
