### PR TITLE
Update PodDisruptionBudget api version to v1 for k8s 1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use base image from `gsoci.azurecr.io`
+- Update api version of `PodDisruptionBudget` to `v1` for k8s 1.25.
 
 ## [0.24.1] - 2024-01-29
 

--- a/helm/app-admission-controller/templates/pdb.yaml
+++ b/helm/app-admission-controller/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "resource.default.name" . }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2970

`v1beta1` is dropped in 1.25 and it is blocking us for 1.25 upgrades.

`v1` is introduced with 1.21 and it is safe to upgrade the version.  See https://gigantic.slack.com/archives/C01F7T2MNRL/p1707988241948399

## Checklist

- [x] Update changelog in CHANGELOG.md.
