### PR TITLE
Decrease retry in cluster app mutation logic to not run out of 10s API timeout for hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Decrease retry interval to 2 seconds (3 times, linear) in cluster app mutation logic to fit into 10s API server
+  timeout limitation for mutating hooks.
+
 ## [1.0.0] - 2024-11-19
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Decrease retry interval to 2 seconds (3 times, linear) in cluster app mutation logic to fit into 10s API server
+- Decrease retry interval to 1 seconds (3 times, linear) in cluster app mutation logic to fit into 10s API server
   timeout limitation for mutating hooks.
 
 ## [1.0.0] - 2024-11-19

--- a/pkg/app/mutate_cluster_app.go
+++ b/pkg/app/mutate_cluster_app.go
@@ -65,7 +65,7 @@ func (m *Mutator) mutateClusterApp(ctx context.Context, app v1alpha1.App) ([]mut
 		}
 		return nil
 	}
-	b := backoff.NewMaxRetries(3, 2*time.Second)
+	b := backoff.NewMaxRetries(3, 1*time.Second)
 	n := backoff.NewNotifier(m.logger, ctx)
 	err := backoff.RetryNotify(getUserValues, b, n)
 	if err != nil {


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.
